### PR TITLE
Fixed Prevent duplicate PR entries in release notes

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -30,6 +30,7 @@ categories:
     label: area/docs
   - title: 🔒 Security
     label: security  
+no-duplicate-categories: true 
 change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
 template: |
   ## What's New


### PR DESCRIPTION
Enable no duplicate categories in release drafter configuration.

**Notes for Reviewers**

- This PR fixes #4 

Added `no-duplicate-categories: true` in [`.github/release-drafter.yml`](https://github.com/meshery/pvtr/blob/master/.github/release-drafter.yml)

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits.
4. Include before and after screenshots/terminal output.

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
