### PR TITLE
docs: update MAINTAINERS.md

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,3 +1,1 @@
-# Meshery Maintainers
-
-See the https://github.com/meshery/meshery repository MAINTAINERS.md document, which defines governance policies for the Meshery project.
+The current maintainers of the Meshery project can be found in the [MAINTAINERS.md](https://github.com/meshery/meshery/blob/master/MAINTAINERS.md) file in the [meshery/meshery](https://github.com/meshery/meshery) repository.

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,1 +1,3 @@
+# Meshery Maintainers
+
 The current maintainers of the Meshery project can be found in the [MAINTAINERS.md](https://github.com/meshery/meshery/blob/master/MAINTAINERS.md) file in the [meshery/meshery](https://github.com/meshery/meshery) repository.


### PR DESCRIPTION
replaced the old plain-text description in MAINTAINERS.md with the official markdown link pointing to the central maintainers list

closes #10


<img width="1919" height="908" alt="image" src="https://github.com/user-attachments/assets/63ad39bf-ac7e-4388-ae29-7e3ce7a61e24" />

